### PR TITLE
Code location correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Subsequent analysis and paper figures are generated using the following function
 
 Following this command, the actual files will be placed in
 
-	~/.local/bin/TimeCellAnalysis
+	~/.local/lib/pythonX/site-packages/TimeCellAnalysis
 
 
 


### PR DESCRIPTION
~/.local/lib/pythonX/site-packages/ has full code in the folder "TimeCellAnalysis". ~/.local/bin/ only has python files. Added the correction.
This is only a README update.